### PR TITLE
Rename  to  to more uniformly indicate functionality

### DIFF
--- a/bundled/src/jsMain/kotlin/DatadogLogger.kt
+++ b/bundled/src/jsMain/kotlin/DatadogLogger.kt
@@ -43,11 +43,11 @@ public actual class DatadogLogger actual constructor(
     }
 
     override fun addAttribute(key: String, value: String) {
-        datadogLogs.setGlobalContextProperty(key, value)
+        datadogLogs.addAttribute(key, value)
     }
 
     override fun removeAttribute(key: String) {
-        datadogLogs.removeGlobalContextProperty(key)
+        datadogLogs.removeAttribute(key)
     }
 }
 

--- a/bundled/src/jsMain/kotlin/external/datadogLogs.kt
+++ b/bundled/src/jsMain/kotlin/external/datadogLogs.kt
@@ -100,9 +100,9 @@ public external interface DatadogLogs {
 
     public val logger: JsLogger
 
-    public fun setGlobalContextProperty(key: String, value: String)
+    public fun addAttribute(key: String, value: String)
 
-    public fun removeGlobalContextProperty(key: String)
+    public fun removeAttribute(key: String)
 }
 
 public external val datadogLogs: DatadogLogs


### PR DESCRIPTION
To match the other platforms, rename `setGlobalContextProperty` and associated remove function to `addAttribute`