### PR TITLE
Disable Android `GradleDependency` lint check

### DIFF
--- a/bundled/build.gradle.kts
+++ b/bundled/build.gradle.kts
@@ -100,6 +100,7 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+        disable += "GradleDependency"
     }
 }
 


### PR DESCRIPTION
There is no need to fail builds/CI due to outdated dependencies.