### PR TITLE
Simplify `binary-compatibility-validator` setup

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ nserrorkt = { module = "com.rickclephas.kmp:nserror-kt", version = "0.2.0" }
 
 [plugins]
 android-library = { id = "com.android.library", version = "8.3.0" }
-api = { id = "binary-compatibility-validator", version = "0.14.0" }
+api = { id = "org.jetbrains.kotlinx.binary-compatibility-validator", version = "0.14.0" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version = "1.9.23" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "4.2.0" }
 maven-publish = { id = "com.vanniktech.maven.publish", version = "0.27.0" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,18 +6,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
     }
-
-    resolutionStrategy {
-        eachPlugin {
-            when {
-                requested.id.namespace == "com.android" ->
-                    useModule("com.android.tools.build:gradle:${requested.version}")
-
-                requested.id.id == "binary-compatibility-validator" ->
-                    useModule("org.jetbrains.kotlinx:binary-compatibility-validator:${requested.version}")
-            }
-        }
-    }
 }
 
 include(


### PR DESCRIPTION
Updates configuration to more closely match [official setup instructions](https://github.com/Kotlin/binary-compatibility-validator?tab=readme-ov-file#setup) (by not configuring/using a shorthand name for the plugin — in other words: no longer using `resolutionStrategy`).