### PR TITLE
Disable `AndroidGradlePluginVersion` lint

### DIFF
--- a/bundled/build.gradle.kts
+++ b/bundled/build.gradle.kts
@@ -100,6 +100,7 @@ android {
     lint {
         abortOnError = true
         warningsAsErrors = true
+        disable += "AndroidGradlePluginVersion"
         disable += "GradleDependency"
     }
 }


### PR DESCRIPTION
Failing a build due to an outdated Android gradle plugin (AGP) is excessive/unnecessary.

Caused merge to `main` to [fail](https://github.com/JuulLabs/datadog-kmp/actions/runs/8347137972/job/22846079199).