### PR TITLE
Update DatadogObjc dependency to v2.4.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 android-compile = "33"
 android-min = "21"
 datadog-android = "2.11.0"
-datadog-ios = "2.0.0"
+datadog-ios = "2.4.0"
 datadog-npm = "4.45.0"
 jvm-toolchain = "11"
 


### PR DESCRIPTION
Using `git bisect`, determined that this is the [newest version available](https://github.com/DataDog/dd-sdk-ios/releases) that doesn't require workarounds (see #77 for details re: issues encountered upgrading further).