### PR TITLE
Add hostname and service to base Datadog REST log

### DIFF
--- a/datadog-ktor/src/commonMain/kotlin/KtorLogger.kt
+++ b/datadog-ktor/src/commonMain/kotlin/KtorLogger.kt
@@ -40,7 +40,10 @@ internal class KtorLogger(
         val baseLogMap: PersistentMap<String, JsonElement> by lazy {
             persistentHashMapOf<String, JsonElement>().mutate { buffer ->
                 globalAttributes.forEach { (key, value) -> buffer[key] = wrapInJsonPrimitive(value) }
+
                 if (config.source != null) buffer["ddsource"] = JsonPrimitive(config.source)
+                if (config.host != null) buffer["hostname"] = JsonPrimitive(config.host)
+                if (config.service != null) buffer["service"] = JsonPrimitive(config.service)
                 if (tagString.isNotEmpty()) buffer["ddtags"] = JsonPrimitive(tagString)
             }
         }


### PR DESCRIPTION
Looks like hostname and service got missed in building the base log for Datadog

Adds these values from the Config object to the base datadog log