### PR TITLE
Only set remote log threshold if configured

### DIFF
--- a/bundled/src/androidMain/kotlin/DatadogLogger.kt
+++ b/bundled/src/androidMain/kotlin/DatadogLogger.kt
@@ -19,8 +19,10 @@ public actual class DatadogLogger actual constructor(
     private val logger: DatadogMultiplatformLogger = DatadogMultiplatformLogger
         .Builder()
         .setName(name)
-        .setRemoteLogThreshold(level?.toDatadogType() ?: LogLevel.CRITICAL)
         .apply {
+            if (level != null) {
+                setRemoteLogThreshold(level.toDatadogType())
+            }
             if (configuration != null) {
                 configuration.serviceName?.let(::setService)
                 setNetworkInfoEnabled(configuration.networkInfoEnabled)


### PR DESCRIPTION
In #154, the default threshold was _accidentally_ set to `CRITICAL`, which would limit logs sent to Datadog to only `CRITICAL` logs if not configured.

This PR "fixes" this, by only setting the threshold if explicitly configured (i.e. set to a log level other than `null`).

By default, Datadog will send all log levels when no threshold is specified.