### PR TITLE
Use `DDLogsConfiguration` single parameter constructor

### DIFF
--- a/bundled/src/iosMain/kotlin/DatadogInitializer.kt
+++ b/bundled/src/iosMain/kotlin/DatadogInitializer.kt
@@ -16,7 +16,7 @@ public actual class DatadogInitializer actual constructor(
             DDConfiguration(configuration),
             trackingConsent.toDatadogType(),
         )
-        if (configuration.features.logs) DDLogs.enableWith(DDLogsConfiguration())
+        if (configuration.features.logs) DDLogs.enableWith(DDLogsConfiguration(null))
         onReady?.invoke()
     }
 


### PR DESCRIPTION
When calling [`DDLogsConfiguration` constructor](https://github.com/DataDog/dd-sdk-ios/blob/2.29.0/DatadogObjc/Sources/Logs/Logs%2Bobjc.swift#L66-L69) using default parameter, it would cause a crash:

```
DatadogObjc/Logs+objc.swift:53: Fatal error: Use of unimplemented initializer 'init()' for class 'DatadogObjc.DDLogsConfiguration'
```

This fixes crash by explicitly calling constructor with a single parameter (which is [how it is done in dd-sdk-kotlin-multiplatform library](https://github.com/DataDog/dd-sdk-kotlin-multiplatform/blob/2ce6850a9db674954883330295fedcad8ec0dd68/features/logs/src/appleMain/kotlin/com/datadog/kmp/log/configuration/internal/IOSLogsConfigurationBuilder.kt#L16)).