### PR TITLE
Add `BatchUploader` interface

### DIFF
--- a/datadog-ktor/api/datadog-ktor.api
+++ b/datadog-ktor/api/datadog-ktor.api
@@ -1,3 +1,8 @@
+public abstract interface class com/juul/datadog/ktor/BatchUploader {
+	public abstract fun launchIn (Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun setTrackingConsent (Lcom/juul/datadog/TrackingConsent;)V
+}
+
 public final class com/juul/datadog/ktor/Configuration {
 	public fun <init> (Lcom/juul/datadog/ktor/Configuration$Endpoint;Lcom/juul/datadog/ktor/Configuration$Log;)V
 	public synthetic fun <init> (Lcom/juul/datadog/ktor/Configuration$Endpoint;Lcom/juul/datadog/ktor/Configuration$Log;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -59,11 +64,11 @@ public final class com/juul/datadog/ktor/Configuration$Log {
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/juul/datadog/ktor/RawBatchUploader {
+public final class com/juul/datadog/ktor/RawBatchUploader : com/juul/datadog/ktor/BatchUploader {
 	public synthetic fun <init> (Lcom/juul/datadog/RawSource;Lcom/juul/datadog/ktor/RawUploader;JIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public synthetic fun <init> (Lcom/juul/datadog/RawSource;Lcom/juul/datadog/ktor/RawUploader;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun launchIn (Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
-	public final fun setTrackingConsent (Lcom/juul/datadog/TrackingConsent;)V
+	public fun launchIn (Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
+	public fun setTrackingConsent (Lcom/juul/datadog/TrackingConsent;)V
 }
 
 public final class com/juul/datadog/ktor/RawLogger : com/juul/datadog/ktor/RestLogger {

--- a/datadog-ktor/src/commonMain/kotlin/BatchUploader.kt
+++ b/datadog-ktor/src/commonMain/kotlin/BatchUploader.kt
@@ -1,0 +1,9 @@
+package com.juul.datadog.ktor
+
+import com.juul.datadog.TrackingConsent
+import kotlinx.coroutines.CoroutineScope
+
+public interface BatchUploader {
+    public fun setTrackingConsent(trackingConsent: TrackingConsent)
+    public fun launchIn(scope: CoroutineScope, onFailure: (Throwable) -> Unit)
+}

--- a/datadog-ktor/src/commonMain/kotlin/RawBatchUploader.kt
+++ b/datadog-ktor/src/commonMain/kotlin/RawBatchUploader.kt
@@ -23,15 +23,15 @@ public class RawBatchUploader(
     private val uploader: RawUploader,
     private val uploadInterval: Duration = 5.seconds,
     private val batchSize: Int = 100,
-) {
+) : BatchUploader {
 
     private val state = MutableStateFlow<TrackingConsent>(Pending)
 
-    public fun setTrackingConsent(trackingConsent: TrackingConsent) {
+    public override fun setTrackingConsent(trackingConsent: TrackingConsent) {
         state.value = trackingConsent
     }
 
-    public fun launchIn(scope: CoroutineScope, onFailure: (Throwable) -> Unit) {
+    public override fun launchIn(scope: CoroutineScope, onFailure: (Throwable) -> Unit) {
         var job: Job? = null
         state
             .onEach {


### PR DESCRIPTION
This will allow consumers to mock out the uploading for tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only API surface change with no runtime behavior change to batch uploading or consent handling.
> 
> **Overview**
> Introduces a public **`BatchUploader`** interface in `datadog-ktor` with **`setTrackingConsent`** and **`launchIn`**, matching the API already exposed by **`RawBatchUploader`**.
> 
> **`RawBatchUploader`** now **implements** **`BatchUploader`**; those two methods are marked **`override`** with no change to upload or consent behavior.
> 
> Consumers can depend on **`BatchUploader`** instead of the concrete class so tests can supply a fake or mock uploader.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6071bc77c470737ffa09cc4213a1677c44d8901. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->